### PR TITLE
Added catch exception when the feature list does not manage to proces…

### DIFF
--- a/js/FeatureList/FeatureList.js
+++ b/js/FeatureList/FeatureList.js
@@ -144,7 +144,14 @@ define(["dojo/Evented", "dojo/_base/declare", "dojo/_base/lang", "dojo/has", "es
                 return t.layer.visible && t.layer.visibleAtMapScale;
             }).forEach(lang.hitch(this.map, function(t) {
                 t.query.geometry = ext.extent;
-                var exp=t.layer.getDefinitionExpression();
+                try{
+                    var exp=t.layer.getDefinitionExpression();
+                    t.query.where = exp;
+                    t.result = t.task.execute(t.query);
+               }
+               catch(err){
+                   console.warn('Layer does not support getDefinitionExpression');
+               }
                 t.query.where = exp;
                 t.result = t.task.execute(t.query);
             }));


### PR DESCRIPTION
…s a layer

When the FeatureList widget fails to read a service that contains
multiple layers the code fails and the application crashes abrubtly.
This code changes simply wraps the logic in a try/catch exception. If
there is problem with a layer, a warning is reported in the console and
the application keep working with the layer that it can support.