### PR TITLE
Solved path issue triggered  by code inconsistency (image/someFilters…

### DIFF
--- a/js/Filters/FilterTab.js
+++ b/js/Filters/FilterTab.js
@@ -170,7 +170,7 @@ define([
                 }                          
             }
             
-            var badgeindicator = query('#badge_somefilters')[0];
+            var badgeindicator = query('#badge_someFilters')[0];
                 if (window.filtersOn.length>0) {
                     domStyle.set(badgeindicator,'display','');
                     domAttr.set(badgeindicator, "title", i18n.widgets.FilterTab.someFilters);

--- a/js/main.js
+++ b/js/main.js
@@ -625,7 +625,7 @@ define(["dojo/ready",
             //Add the legend tool to the toolbar. Only activated if the web map has operational layers.
             var deferred = new Deferred();
             if (has("filter")) {
-                var filterDiv = toolbar.createTool(tool, "", "", "somefilters");
+                var filterDiv = toolbar.createTool(tool, "", "", "someFilters");
 
                 var layers = this.config.response.itemInfo.itemData.operationalLayers;
                 


### PR DESCRIPTION
….png)

The code seems to use a hard coded string to fetch the image in
images/someFilters.png. The string is lower case whereas the image file
name is not. This issue shows up only on Unix like system since Windows
file names are case insensitive.