### PR TITLE
Added a minimal extent for the seach to zoom at.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -14,41 +14,41 @@
  | limitations under the License.
  */
 
-define(["dojo/ready", 
+define(["dojo/ready",
     "dojo/aspect", "dijit/registry",
-    "dojo/json", "dojo/_base/array", "dojo/_base/Color", "dojo/_base/declare", 
-    "dojo/_base/lang", "dojo/dom", "dojo/dom-geometry", "dojo/dom-attr", "dojo/dom-class", 
-    "dojo/dom-construct", "dojo/dom-style", "dojo/on", "dojo/Deferred", "dojo/promise/all", 
-    "dojo/query", "dijit/Menu", "dijit/CheckedMenuItem", "application/toolbar", 
-    "application/has-config", "esri/arcgis/utils", "esri/lang", 
+    "dojo/json", "dojo/_base/array", "dojo/_base/Color", "dojo/_base/declare",
+    "dojo/_base/lang", "dojo/dom", "dojo/dom-geometry", "dojo/dom-attr", "dojo/dom-class",
+    "dojo/dom-construct", "dojo/dom-style", "dojo/on", "dojo/Deferred", "dojo/promise/all",
+    "dojo/query", "dijit/Menu", "dijit/CheckedMenuItem", "application/toolbar",
+    "application/has-config", "esri/arcgis/utils", "esri/lang",
     "dijit/layout/BorderContainer", "dijit/layout/ContentPane", "dijit/focus",
-    "esri/tasks/query", 
-    "esri/dijit/HomeButton", "esri/dijit/LocateButton", 
-    "esri/dijit/Legend", "esri/dijit/BasemapGallery", 
+    "esri/tasks/query",
+    "esri/dijit/HomeButton", "esri/dijit/LocateButton",
+    "esri/dijit/Legend", "esri/dijit/BasemapGallery",
     "dojo/i18n!application/nls/resources",
     "dojo/i18n!application/nls/BaseMapLabels",
-    "esri/dijit/Measurement", "esri/dijit/OverviewMap", "esri/geometry/Extent", 
-    "esri/layers/FeatureLayer", "application/NavToolBar/NavToolBar", 
-    "application/FeatureList/FeatureList", "application/Filters/Filters", "application/TableOfContents", 
+    "esri/dijit/Measurement", "esri/dijit/OverviewMap", "esri/geometry/Extent",
+    "esri/layers/FeatureLayer", "application/NavToolBar/NavToolBar",
+    "application/FeatureList/FeatureList", "application/Filters/Filters", "application/TableOfContents",
     "application/LanguageSelect/LanguageSelect",
     "application/ShareDialog", //"application/SearchSources",
     "esri/symbols/SimpleMarkerSymbol", "esri/symbols/PictureMarkerSymbol", "esri/graphic",
     "esri/dijit/InfoWindow",
-    "dojo/NodeList-dom", "dojo/NodeList-traverse"], 
+    "dojo/NodeList-dom", "dojo/NodeList-traverse"],
     function (
-    ready, 
+    ready,
     aspect, registry,
-    JSON, array, Color, declare, 
-    lang, dom, domGeometry, domAttr, domClass, 
-    domConstruct, domStyle, on, Deferred, all, 
-    query, Menu, CheckedMenuItem, Toolbar, 
-    has, arcgisUtils, esriLang, 
+    JSON, array, Color, declare,
+    lang, dom, domGeometry, domAttr, domClass,
+    domConstruct, domStyle, on, Deferred, all,
+    query, Menu, CheckedMenuItem, Toolbar,
+    has, arcgisUtils, esriLang,
     BorderContainer, ContentPane, focusUtil,
     Query,
-    HomeButton, LocateButton, 
-    Legend, BasemapGallery, 
+    HomeButton, LocateButton,
+    Legend, BasemapGallery,
     i18n, i18n_BaseMapLabels,
-    Measurement, OverviewMap, Extent, 
+    Measurement, OverviewMap, Extent,
     FeatureLayer, NavToolBar,
     FeatureList, Filters, TableOfContents, LanguageSelect,
     ShareDialog, //SearchSources,
@@ -66,7 +66,7 @@ define(["dojo/ready",
         editor: null,
         editableLayers: null,
         timeFormats: ["shortDateShortTime", "shortDateLEShortTime", "shortDateShortTime24", "shortDateLEShortTime24", "shortDateLongTime", "shortDateLELongTime", "shortDateLongTime24", "shortDateLELongTime24"],
-        
+
         startup: function (config) {
             // config will contain application and user defined info for the template such as i18n strings, the web map id
             // and application id and any url parameters and any application specific configuration information.
@@ -107,7 +107,7 @@ define(["dojo/ready",
                     img:this.config.lang1imageSrc,
                     shortName:this.config.lang1shortName,
                     name:this.config.lang1name,
-                    appId:this.config.lang1appId 
+                    appId:this.config.lang1appId
                 },
                 {
                     code:this.config.lang2code,
@@ -171,13 +171,13 @@ define(["dojo/ready",
 
             query(".esriSimpleSlider").style("backgroundColor", this.theme.toString());
             // remove loading class from body
-            
+
             domClass.remove(document.body, "app-loading");
             on(window, "orientationchange", lang.hitch(this, this._adjustPopupSize));
             this._adjustPopupSize();
 
             var _map = this.map;
-                        
+
             on(this.map.infoWindow, "show", lang.hitch(this, function() {
                 this._initPopup(this.map.infoWindow.domNode);
             }));
@@ -193,7 +193,7 @@ define(["dojo/ready",
                 if(!dojo.getAttr(images[i], 'alt'))
                 {
                     dojo.setAttr(images[i], 'alt', '');
-                } 
+                }
             }
 
             dojo.setAttr(node, "role", "dialog");
@@ -248,11 +248,11 @@ define(["dojo/ready",
         _createUI: function () {
             var borderContainer = new BorderContainer({
                 //design:'sidebar',
-                gutters:'false', 
+                gutters:'false',
                 liveSplitters:'false',
                 id:"borderContainer"
             });
-             
+
             var contentPaneTop = new ContentPane({
                 region: "top",
                 splitter: 'false',
@@ -262,7 +262,7 @@ define(["dojo/ready",
                 //class: "splitterContent",
             });
             borderContainer.addChild(contentPaneTop);
-              
+
             var contentPaneLeft = new ContentPane({
                 region: "leading",
                 splitter: 'true',
@@ -271,7 +271,7 @@ define(["dojo/ready",
                 class: "splitterContent",
             });
             borderContainer.addChild(contentPaneLeft);
-              
+
             var contentPaneRight = new ContentPane({
                 style: "padding:1px;",
                 region: "center",
@@ -290,7 +290,7 @@ define(["dojo/ready",
                 this.map.resize();
                 this.map.reposition();
             }));
-            
+
             domStyle.set("panelPages", "visibility", "hidden");
             //Add tools to the toolbar. The tools are listed in the defaults.js file
             var toolbar = new Toolbar(this.config);
@@ -348,7 +348,7 @@ define(["dojo/ready",
                             break;
                     }
                 }
-    
+
                 all(toolList).then(lang.hitch(this, function (results) {
 
 
@@ -426,7 +426,7 @@ define(["dojo/ready",
                     default:
                         break;
                 }
-                
+
             });
 
             on(document.body, 'keyup', function(event) {
@@ -474,7 +474,7 @@ define(["dojo/ready",
                     style:'left:20%; top:-75%;'
                 }, dom.byId('panelBottom'));
             }
-            
+
             var skipTools = query('.skip #skip-tools')[0];
             var skipSearch = query('.skip #skip-search')[0];
             var skipContent = query('.skip #skip-content')[0];
@@ -558,7 +558,7 @@ define(["dojo/ready",
                     activeTool = activeTool[0].childNodes[0];
                     activeTool.click();
                 }
-                dom.byId('instructionsDiv').focus();            
+                dom.byId('instructionsDiv').focus();
             };
 
             skipToFeature = function() {
@@ -577,7 +577,7 @@ define(["dojo/ready",
                 var featuresDiv = toolbar.createTool(tool, "", "reload1.gif", "featureSelected");
 
                 var layers = this.config.response.itemInfo.itemData.operationalLayers;
-                
+
                 featureList = new FeatureList({
                     map: this.map,
                     layers: layers,
@@ -593,22 +593,22 @@ define(["dojo/ready",
                 // }));
 
                 deferred.resolve(true);
-            } 
+            }
             else {
                 // window._prevSelected = null;
                 deferred.resolve(false);
             }
-        
+
             return deferred.promise;
         },
-        
+
         navDeferred : null,
 
         _addNavigation: function (tool, oldNaviagationToolBar, deferred) {
             var navToolBar = domConstruct.create("div", {
                 id: "newNaviagationToolBar",
             });
-            
+
             nav = new NavToolBar({
                 map: this.map,
                 navToolBar: oldNaviagationToolBar,
@@ -628,7 +628,7 @@ define(["dojo/ready",
                 var filterDiv = toolbar.createTool(tool, "", "", "someFilters");
 
                 var layers = this.config.response.itemInfo.itemData.operationalLayers;
-                
+
                 filter = new Filters({
                     map: this.map,
                     layers: layers,
@@ -641,15 +641,15 @@ define(["dojo/ready",
                 // }));
 
                 deferred.resolve(true);
-            } 
+            }
             else {
                 // window._prevSelected = null;
                 deferred.resolve(false);
             }
-        
+
             return deferred.promise;
         },
-        
+
         _addBasemapGallery: function (tool, toolbar) {
             var deferred = new Deferred();
             if (has("basemap")) {
@@ -677,12 +677,12 @@ define(["dojo/ready",
                             if(dojo.hasClass(node, "esriBasemapGallerySelectedNode"))
                             {
                                 l += ' '+this.config.i18n.tools.basemapGallery.selected;
-                            }       
-                            l += '.';                          
+                            }
+                            l += '.';
                             //node.querySelector('a').focus();
                             domAttr.set(aSpan, 'aria-label', l);
                             //aSpan.focus();
-                        });    
+                        });
                     });
 
                     var observerCfg = { attributes: true, childList: false, characterData: false };
@@ -717,17 +717,17 @@ define(["dojo/ready",
                             if(dojo.hasClass(node, "esriBasemapGallerySelectedNode"))
                             {
                                 l += ' '+this.config.i18n.tools.basemapGallery.selected;
-                            }       
-                            l += '.';                          
+                            }
+                            l += '.';
                             domAttr.set(aSpan, 'aria-label', l);
                             //img.alt=aSpan.innerText;
                         } catch(e) {}
-                        
-                        domAttr.set(labelNode, "tabindex", 0);   
+
+                        domAttr.set(labelNode, "tabindex", 0);
                         on(img, "click", function() { node.focus();});
                         on(node,"keydown", function(ev) {
                             if(ev.key === "Enter" || ev.key === " " || ev.char === " ") {
-                                aNode.click();  
+                                aNode.click();
                             } else if(ev.key === "Tab" && !ev.shiftKey) {
                                 if(node.nextElementSibling.nodeName != "BR") {
                                     node.nextElementSibling.focus();
@@ -825,12 +825,12 @@ define(["dojo/ready",
             var deferred = new Deferred();
             if (!has("instructions")) {
                deferred.resolve(false);
-            } 
-            else 
-            { 
+            }
+            else
+            {
                 if(!has("details"))
                 {
-                    require(["dojo/text!application/dijit/templates/"+this.config.i18n.instructions+".html"], 
+                    require(["dojo/text!application/dijit/templates/"+this.config.i18n.instructions+".html"],
                         function(instructionsText){
                         var instructionsDiv = toolbar.createTool(tool);
                         domConstruct.create('div',{
@@ -842,10 +842,10 @@ define(["dojo/ready",
 
                     var instructionsBtn = dojo.query("#toolButton_instructions")[0];
                     domClass.add(instructionsBtn, "panelToolDefault");
-                } 
+                }
                 else {
                     deferedDetails.then(lang.hitch(this, function(r) {
-                        require(["dojo/text!application/dijit/templates/"+this.config.i18n.instructions+".html"], 
+                        require(["dojo/text!application/dijit/templates/"+this.config.i18n.instructions+".html"],
                             function(instructionsText){
                             var instructionsDiv = domConstruct.create('div',{
                                 id:"instructionsDiv",
@@ -870,7 +870,7 @@ define(["dojo/ready",
                 var detailDiv = dojo.byId('detailDiv');
                 detailDiv.style.maxHeight=(pageBody.clientHeight-instructionsDiv.clientHeight - 30) + 'px';
             } catch (e) {
-                /* ignore instructionDiv not defined error: will come defined next time! */      
+                /* ignore instructionDiv not defined error: will come defined next time! */
             }
         },
 
@@ -1093,7 +1093,7 @@ define(["dojo/ready",
                             domAttr.set(messages[m],'tabindex',0);
                         }
                     };
-                    
+
                     on(this.map, "extent-change", lang.hitch(this, fixLegend));
                     // dojo.setAttr(legendDiv, 'tabindex', 0);
 
@@ -1134,7 +1134,7 @@ define(["dojo/ready",
                 for(i = 0; i< esriMeasurementTableHeaders.length; i++)
                 {
                     esriMeasurementTableHeader = esriMeasurementTableHeaders[i];
-                    //alert(esriMeasurementTableHeader.innerHTML); 
+                    //alert(esriMeasurementTableHeader.innerHTML);
                     var newHeader = document.createElement('th');
                     newHeader.innerHTML = esriMeasurementTableHeader.innerHTML;
                     colspan = esriMeasurementTableHeader.getAttribute('colspan');
@@ -1148,7 +1148,7 @@ define(["dojo/ready",
                 var AccessAuditMarkers = esriMeasurementResultTable.querySelectorAll('img');
                 for(i = 0; i< AccessAuditMarkers.length; i++)
                 {
-                     AccessAuditMarkers[i].setAttribute('Alt','');  
+                     AccessAuditMarkers[i].setAttribute('Alt','');
                 }
 
                 areaIconNode = measureDiv.querySelector('.areaIcon');
@@ -1180,7 +1180,7 @@ define(["dojo/ready",
                 var panelHeight = this.map.height;
 
                 this.createOverviewMap(ovMapDiv, panelHeight);
-                
+
                 on(this.map, "layer-add", lang.hitch(this, function (args) {
                     //delete and re-create the overview map if the basemap gallery changes
                     if (args.layer.hasOwnProperty("_basemapGalleryLayerType") && args.layer._basemapGalleryLayerType === "basemap") {
@@ -1465,7 +1465,7 @@ define(["dojo/ready",
             if (has("share")) {
 
                 var shareDiv = domConstruct.create('div', {class:'pageBody'},toolbar.createTool(tool));//);
-                
+
                 var shareDialog = new ShareDialog({
                     bitlyLogin: this.config.bitlyLogin,
                     bitlyKey: this.config.bitlyKey,
@@ -1519,8 +1519,8 @@ define(["dojo/ready",
             }));
 
             //Add the location search widget
-            require(["application/has-config!search?esri/dijit/Search", 
-                "application/has-config!search?esri/tasks/locator"], 
+            require(["application/has-config!search?esri/dijit/Search",
+                "application/has-config!search?esri/tasks/locator"],
                 lang.hitch(this, function (Search, Locator) {
                 if (!Search && !Locator) {
                     //add class so we know we don't have to hide title since search isn't visible
@@ -1539,9 +1539,10 @@ define(["dojo/ready",
                 var search = new Search(options, domConstruct.create("div", {
                     id: "search"
                 }, "mapDiv"));
+                search.zoomScale = 25000;
                 var defaultSources = [];
 
-                //setup geocoders defined in common config 
+                //setup geocoders defined in common config
                 if (this.config.helperServices.geocode && this.config.locationSearch) {
                     var geocoders = lang.clone(this.config.helperServices.geocode);
                     array.forEach(geocoders, lang.hitch(this, function (geocoder) {
@@ -1564,7 +1565,7 @@ define(["dojo/ready",
                             defaultSources.push(geocoder);
                         } else if (esriLang.isDefined(geocoder.singleLineFieldName)) {
 
-                            //Add geocoders with a singleLineFieldName defined 
+                            //Add geocoders with a singleLineFieldName defined
                             geocoder.locator = new Locator(geocoder.url);
 
                             defaultSources.push(geocoder);
@@ -1572,7 +1573,7 @@ define(["dojo/ready",
                     }));
                 }
 
-                //add configured search layers to the search widget 
+                //add configured search layers to the search widget
                 var configuredSearchLayers = (this.config.searchLayers instanceof Array) ? this.config.searchLayers : JSON.parse(this.config.searchLayers);
 
                 array.forEach(configuredSearchLayers, lang.hitch(this, function (layer) {
@@ -1595,12 +1596,12 @@ define(["dojo/ready",
                     }
                 }));
 
-                //Add search layers defined on the web map item 
-                if (this.config.response.itemInfo.itemData && 
-                    this.config.response.itemInfo.itemData.applicationProperties && 
-                    this.config.response.itemInfo.itemData.applicationProperties.viewing && 
+                //Add search layers defined on the web map item
+                if (this.config.response.itemInfo.itemData &&
+                    this.config.response.itemInfo.itemData.applicationProperties &&
+                    this.config.response.itemInfo.itemData.applicationProperties.viewing &&
                     this.config.response.itemInfo.itemData.applicationProperties.viewing.search) {
-                    
+
                     var searchOptions = this.config.response.itemInfo.itemData.applicationProperties.viewing.search;
 
                     array.forEach(searchOptions.layers, lang.hitch(this, function (searchLayer) {
@@ -1648,7 +1649,7 @@ define(["dojo/ready",
                     if(!source.placeholder || source.placeholder === undefined || source.placeholder ==="") {
                         if(source.featureLayer && source.featureLayer.name) {
                             source.placeholder = i18n.searchEnterCriteria+" "+source.featureLayer.name;
-                        } 
+                        }
                         else {
                             source.placeholder = i18n.searchPlaceholder;
                         }
@@ -1660,13 +1661,13 @@ define(["dojo/ready",
 
                 if (search && search.domNode) {
                     domConstruct.place(search.domNode, "panelGeocoder");
-            
+
                     var esriIconDownArrowNode = dojo.query(".searchIcon.esri-icon-down-arrow")[0];
                     if(esriIconDownArrowNode)
                     {
                         domClass.remove(esriIconDownArrowNode, "searchIcon esri-icon-down-arrow");
 
-                        esriIconDownArrowNode.innerHTML = 
+                        esriIconDownArrowNode.innerHTML =
                         '<img src="images\\downArrow.png" alt="Search in" width="20" height="20">';
                     }
 
@@ -1677,14 +1678,14 @@ define(["dojo/ready",
                     if(esriIconZoomNode)
                     {
                         domClass.remove(esriIconZoomNode, "searchIcon esri-icon-search");
-                        esriIconZoomNode.innerHTML = 
+                        esriIconZoomNode.innerHTML =
                         '<img src="images\\searchZoom.png" alt="Search" width="20" height="20">';
                     }
 
-                    var esriIconCloseNode = dojo.query(".searchIcon.esri-icon-close.searchClose")[0]; 
+                    var esriIconCloseNode = dojo.query(".searchIcon.esri-icon-close.searchClose")[0];
                     if(esriIconCloseNode) {
                         domClass.remove(esriIconCloseNode, "searchIcon esri-icon-close");
-                        esriIconCloseNode.innerHTML = 
+                        esriIconCloseNode.innerHTML =
                             '<img src="images\\searchClear.png" alt="Clear search" width="16" height="16">';
                     }
                 }
@@ -1727,7 +1728,7 @@ define(["dojo/ready",
                                 dojo.removeAttr(box, 'tabindex');
                                 dojo.removeAttr(box, 'aria-label');
                             }
-                        });    
+                        });
                     });
 
                     var observerCfg = { attributes: true, childList: false, characterData: false };
@@ -1740,7 +1741,7 @@ define(["dojo/ready",
             //create the tools
             this._createUI();
         },
- 
+
         _updateTheme: function () {
 
             //Set the background color using the configured theme value
@@ -1796,7 +1797,7 @@ define(["dojo/ready",
                             //rule.style.boxShadow = "3px 3px 10px "+this._rgbaColor(this.focusColor);
                         }
                         //active
-                        if(rule.selectorText.indexOf('.activeMarker') >= 0 || 
+                        if(rule.selectorText.indexOf('.activeMarker') >= 0 ||
                             //rule.selectorText.indexOf('.goThereHint') >= 0 ||
                             rule.selectorText.indexOf('dijitSplitterThumb') >= 0) {
                             rule.style.backgroundColor = this._rgbaColor(this.activeColor);
@@ -1822,7 +1823,7 @@ define(["dojo/ready",
                 this.mapExt = this.map.extent;
             }
         },
- 
+
         _adjustPopupSize: function () {
             if (!this.map) {
                 return;
@@ -1841,13 +1842,13 @@ define(["dojo/ready",
             }
             this.map.infoWindow.resize(width, height);
         },
- 
+
         _createWebMap: function (itemInfo) {
 
             window.config = this.config;
 
             var options = {};
-            //specify center and zoom if provided as url params 
+            //specify center and zoom if provided as url params
             if (this.config.level) {
                 options.zoom = this.config.level;
             }
@@ -1870,7 +1871,7 @@ define(["dojo/ready",
 
                 var mapDiv = document.querySelector('#mapDiv');
                 on(mapDiv, 'keydown', lang.hitch(this, function(evn){
-                    if(!document.querySelector(':focus') || document.querySelector(':focus').id !== "mapDiv") return; 
+                    if(!document.querySelector(':focus') || document.querySelector(':focus').id !== "mapDiv") return;
                     switch(evn.keyCode)  {
                         case 40 : //down
                             this.map._fixedPan(0, this.map.height * 0.0135);
@@ -1915,7 +1916,7 @@ define(["dojo/ready",
                     }
                 }));
                 on(mapDiv, 'keypress', lang.hitch(this, function(evn){
-                  if(!document.querySelector(':focus') || document.querySelector(':focus').id !== "mapDiv") return;  
+                  if(!document.querySelector(':focus') || document.querySelector(':focus').id !== "mapDiv") return;
                   evn.preventDefault();
                   evn.stopPropagation();
                   if((evn.keyCode === 43) && !evn.ctrlKey && !evn.altKey)  // Shift-'+'
@@ -1943,7 +1944,7 @@ define(["dojo/ready",
                     var altMapText = esriLang.stripTags(this.config.altMapText);
                     domAttr.set(this.map.container, "aria-label", altMapText);
                 }
-                
+
                 //Add a logo if provided
                 if (this.config.logo) {
                     var altText = this.config.logoAltText;
@@ -1951,7 +1952,7 @@ define(["dojo/ready",
                         altText = title;
                     var panelLogo = domConstruct.create("div", {
                         id: "panelLogo",
-                        TabIndex:0, 
+                        TabIndex:0,
                         innerHTML: "<img id='logo' src=" + this.config.logo + " alt='" + altText + "' Title='" + altText + "' aria-label='" + altText + "'></>"
                     }, dom.byId("panelTitle"));//, "first");
                     //domClass.add("panelTop", "largerTitle");
@@ -1962,7 +1963,7 @@ define(["dojo/ready",
                 //this.map = response.map;
                 //Set the title - use the config value if provided.
                 //var title = (this.config.title === null) ? response.itemInfo.item.title : this.config.title;
-          
+
                 //if title is short make title area smaller
                 if (title && title.length && title.length === 0) {
                     domClass.add("panelTop", "smallerTitle");
@@ -1995,12 +1996,12 @@ define(["dojo/ready",
                     this.map.setExtent(this.initExt);
                 }
                 window.initExt = this.initExt = this.map.extent;
-                
+
                 on.once(this.map, "extent-change", lang.hitch(this, function() {
                     navDeferred.then(lang.hitch(this, function (results) {
                         this._checkExtent();
                         var homeButton = document.querySelector(".HomeButton input[type='image']");
-                        if(homeButton) 
+                        if(homeButton)
                             homeButton.click();
                     }));
 


### PR DESCRIPTION
When zooming on a point the search widget, the widget has a tendency to
go beyond the maximum zoom level supported by ArcGIS Online base maps.
This proposed fix sets a minimum scale for the search widget, to keep it
visible with the basemap, when the result set does not have an extent.