### PR TITLE
Fix markdown link formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This template includes many WCAG 2.0 A, AA and AAA capabilities, which serves as
 
 ![Screen Shot](https://github.com/EsriCanada/WCAG-BasicViewer/blob/master/WCAGViewer.png)
 
-[View it live] (https://arcgis103.esri.ca/WCAG-Configurable-Template-Test/index.html?appid=b54efa235b7f455f91b14396090ad3e3)
+[View it live](https://arcgis103.esri.ca/WCAG-Configurable-Template-Test/index.html?appid=b54efa235b7f455f91b14396090ad3e3)
 
 #Features
 The template can be configured using the following options:


### PR DESCRIPTION
As an aside, the link takes you to the [WCAG map demo](https://arcgis103.esri.ca/WCAG-Configurable-Template-Test/index.html?appid=b54efa235b7f455f91b14396090ad3e3) but the map never loads. I see some failing XHR's in my dev tools network inspector, might be it. It'd be great to be able to view the demo...